### PR TITLE
Use cross-env for environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -453,7 +453,7 @@ And finally, add the build script to your `package.json` (replacing `./lib` with
 directory):
 
 ```bash
-NODE_ENV=production BABEL_ENV=cjs babel ./lib -d cjs
+cross-env NODE_ENV=production BABEL_ENV=cjs babel ./lib -d cjs
 ```
 
 Which will transpile the javascript files in `lib/` into `cjs/` using the `cjs` babel environment
@@ -482,7 +482,7 @@ Following from above, because you've switched to using `babel-preset-es2015-no-c
 generating the ES6 version doesn't require any further configuration and can be done using just:
 
 ```bash
-NODE_ENV=production babel ./lib -d es6
+cross-env NODE_ENV=production babel ./lib -d es6
 ```
 
 ##### Bundled version:
@@ -549,7 +549,7 @@ const config = {
 Finally, the build script is just:
 
 ```bash
-NODE_ENV=production BABEL_ENV=bundle webpack -p
+cross-env NODE_ENV=production BABEL_ENV=bundle webpack -p
 ```
 
 ##### What about other assets?

--- a/package.json
+++ b/package.json
@@ -13,10 +13,10 @@
   },
   "scripts": {
     "lint": "eslint ./",
-    "build": "rimraf ./build && NODE_ENV=extract webpack",
-    "build:dist": "rimraf ./dist && NODE_ENV=production webpack -p",
+    "build": "rimraf ./build && cross-env NODE_ENV=extract webpack",
+    "build:dist": "rimraf ./dist && cross-env NODE_ENV=production webpack -p",
     "clean": "rimraf ./build ./dist",
-    "start": "NODE_ENV=demo node server.demo.js",
+    "start": "cross-env NODE_ENV=demo node server.demo.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "devDependencies": {
@@ -32,6 +32,7 @@
     "babel-preset-es2015-no-commonjs": "0.0.2",
     "babel-preset-react": "^6.5.0",
     "babel-runtime": "^6.9.0",
+    "cross-env": "^1.0.8",
     "css-loader": "^0.23.1",
     "dotenv": "^2.0.0",
     "eslint": "^2.10.2",


### PR DESCRIPTION
Use cross-env package to safely set unix-style environment variables on Windows.
