### PR TITLE
Revert eslint-plugin-jsx-a11y upgrade until their 3.0 is fixed

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "eslint": "^3.8.0",
     "eslint-config-ascribe-react": "^1.4.0",
     "eslint-plugin-import": "^2.0.1",
-    "eslint-plugin-jsx-a11y": "^3.0.0",
+    "eslint-plugin-jsx-a11y": "^2.2.3",
     "eslint-plugin-react": "^6.4.1",
     "extract-text-webpack-plugin": "=2.0.0-beta.1",
     "postcss-loader": "^0.13.0",


### PR DESCRIPTION
[3.0.0 was pulled until a new feature lands](https://github.com/evcohen/eslint-plugin-jsx-a11y/commit/4ecae6a55b2c8aa4d0b901f962970f7650d49383).
